### PR TITLE
Add Command Batching

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var path = require('path');
 var vagrant = process.env.VAGRANT_DIR ? path.join(process.env.VAGRANT_DIR, 'vagrant') : 'vagrant';
 
 var SSH_CONFIG_MATCHERS = {
+    host: /Host (\S+)$/mi,
     port: /Port (\S+)$/mi,
     hostname: /HostName (\S+)$/mi,
     user: /User (\S+)$/mi,


### PR DESCRIPTION
Because Vagrant only allows one process to call at a time, it becomes hard managing multiple calls together. Instead of simply throwing an error, batch the calls and call them in sequence.

Note: Includes an unrelated, previous commit that adds a `host` field for a named machine for `Machine#sshConfig`