### PR TITLE
SSH Parser No Private Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,77 +19,124 @@ Usage
 ===
 
 All callbacks are node style:
-```
-function(err, out) { ...
+```js
+function(err, out)
 ```
 where err is stderr if exit code != 0 and out is stdout if exit code == 0
 ___
 Other commands
-```
+```js
 // import vagrant
 var vagrant = require('node-vagrant');
 
 // view version
-vagrant.version(function(err, out) ...
+vagrant.version(function(err, out) {});
 
 // view global status
-//you can specify '--prune' as additional argument. By default global-status is based on a cache, 
-//prune removes invalid entries from the list. 
+//you can specify '--prune' as additional argument. By default global-status is based on a cache,
+//prune removes invalid entries from the list.
 //Note that this is much more time consuming than simply listing the entries.
-vagrant.globalStatus(function(err, out) ...
-vagrant.globalStatus('--prune', function(err, out) ...
-// out is [] array of {} objects with properties: id, name, provider, state, cwd
+vagrant.globalStatus(function(err, out) {});
+vagrant.globalStatus('--prune', function(err, out) {});
 
-
+// vagrant machine
 
 // create machine - does not run command or init machine
 // you can specify directory where Vagrantfile will be located
 // and machine instanced
-var machine = vagrant.create({ cwd: ..., env: ... });
+var machine = vagrant.create({ cwd: [], env: [] });
 
 // init machine
 // you can specify additional arguments by using array (applicable to other functions)
-machine.init('ubuntu/trusty64', function(err, out) ...
-machine.init(['ubuntu/trusty64'], function(err, out) ...
+machine.init('ubuntu/trusty64', function(err, out) {});
+machine.init(['ubuntu/trusty64'], function(err, out) {});
 // -f is set by default
-machine.init(['ubuntu/trusty64', '-f'], function(err, out) ...
+machine.init(['ubuntu/trusty64', '-f'], function(err, out) {});
 
 // up
-machine.up(function(err, out) ...
+machine.up(function(err, out) {})
 
 // status
-machine.status(function(err, out) ...
+machine.status(function(err, out) {});
 
 // get ssh config - useful to retrieve private and connect to machine with ssh2
-machine.sshConfig(function(err, out) ...
 // out is object {} with properties: port, hostname, user, private_key
+machine.sshConfig(function(err, out) {});
 
 // suspend
-machine.suspend(function(err, out) ...
+machine.suspend(function(err, out) {});
 
 // resume
-machine.resume(function(err, out) ...
+machine.resume(function(err, out) {});
 
 // halt
-machine.halt(function(err, out) ...
+machine.halt(function(err, out) {});
 
-// destroy - uses -f by default
-machine.destroy(function(err, out) ...
+// destroy
+// uses -f by default
+machine.destroy(function(err, out) {});
 
 // snapshots
-push, pop, save, delete, restore, list and a snapshot() function.
-
-Example usage: 
+// push, pop, save, delete, restore, list and a snapshot() function.
+// example:
 machine.snapshots().push(cb);
 
+// box repackage
+// must be specific to a vagrant environment hence location in machine
+machine.boxRepackage(name, provider, version, function(err, out) {});
+
+
+// boxes
+
+// box add
+// uses -f by default
+// depending on type of box provided (name,address,file,json) missing information may be prompted.
+// please ensure that your add metheod is specific.
+vagrant.boxAdd(box, args, function(err, out) {})
+    .on('progress', function(out) {});
+
+// box list
+// out is object {} with properties: name, provider, version
+vagrant.boxList(args, function(err, out) {});
+
+// box outdated
+// --global is used by default
+// out is object {} with properties: name, status, currentVersion, latestVersion
+// status can be 'up to date' 'out of date' 'unknown'
+// if status is unknown currentVersion and latestVersion will be null
+vagrant.boxOutdated(args, function(err, out) {});
+
+// box prune
+// uses -f by defaultprune
+vagrant.boxPrune(args, function(err, out) {});
+
+// box remove
+// uses -f by default
+vagrant.boxRemove(name, args, function(err, out) {});
+
+// box repackage
+// avalible in machine
+
+// box update
+// uses the --box and --provider flags by default
+vagrant.boxUpdate(box, provider, function(err, out) {});
+    .on('progress', function(out) {});
+
+
+// args
+// should be array of args or a string for single flag see --prune abov
+// ie
+vagrant.boxAdd('ubuntu/trusty64', ['--clean', '--provider', 'virtualbox'], function(err, out) {})
+//or simply
+vagrant.boxAdd('ubuntu/trusty64', '--clean', function(err, out) {})
 ```
 
 Events
 ===
-```
-.on('up-progress', function(out) ... // receive stdout progress from up of vagrant
+```js
+.on('up-progress', function(out) {}); // receive stdout progress from up of vagrant
 
-.on('progress', function(out) ... // receive stdout box download progress
+.on('progress', function(out) {}); // receive stdout box download progress
 ```
 
 Example

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     {
       "name": "Leonardo Nahra",
       "url": "https://github.com/lanahra"
+    },
+    {
+      "name": "Tyler Stiene",
+      "url": "https://github.com/Stieneee"
     }
   ],
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function Machine(opts) {
     }
 
     this.batch = [];
-    
+
     this.opts = opts;
     this.opts.cwd = this.opts.cwd || process.cwd();
     this.opts.env = this.opts.env || process.env;
@@ -39,10 +39,14 @@ function _command(name, args, more) {
 
     args = args.concat(more);
 
-    return [name].concat(args);
+    if (!Array.isArray(name)) {
+        name = [name];
+    }
+
+    return name.concat(args);
 }
 
-function run(command, opts, cb) {
+module.exports._run = function (command, opts, cb) {
     var args = [].slice.call(arguments);
 
     if (args.length === 1) {
@@ -86,8 +90,7 @@ function run(command, opts, cb) {
     }
 
     return child;
-}
-
+};
 
 Machine.prototype._run = function (command, cb) {
     var self = this;
@@ -100,7 +103,7 @@ Machine.prototype._run = function (command, cb) {
 
     // var out = '';
     // var err = '';
-    var child = run(command, {
+    var child = module.exports._run(command, {
         cwd: self.opts.cwd,
         env: self.opts.env
     }, function (err, data) {
@@ -304,6 +307,21 @@ Machine.prototype.snapshots = function () {
     };
 };
 
+Machine.prototype.boxRepackage = function (name, provider, version, cb) {
+    if (typeof name !== 'string') {
+        cb('name must be provided as a string');
+    }
+    if (typeof provider !== 'string') {
+        cb('provider must be provided as a string');
+    }
+    if (typeof version !== 'string') {
+        cb('version must be provided as a string');
+    }
+
+    var command = _command(['box', 'repackage', name, provider, version]);
+    this._run(command, cb);
+};
+
 Machine.prototype._generic = function (name, args, cb) {
     this._run(_command(name, args), cb);
 };
@@ -314,7 +332,7 @@ module.exports.globalStatus = function (args, cb) {
     cb = cb || args;
 
     var command = _command('global-status', args);
-    run(command, function (err, out) {
+    module.exports._run(command, function (err, out) {
         if (err) {
             return cb(err);
         }
@@ -328,5 +346,87 @@ module.exports.create = function (opts) {
 };
 
 module.exports.version = function (cb) {
-    run(_command('version'), cb);
+    module.exports._run(_command('version'), cb);
+};
+
+module.exports.boxAdd = function (box, args, cb) {
+    if (typeof box !== 'string' && cb) {
+        cb('box must be provided as a string');
+    }
+    cb = cb || args;
+
+    var command = _command(['box', 'add', '-f'], args, box);
+    var proc = module.exports._run(command, cb);
+
+    var emitter = new EventEmitter;
+    proc.stdout.on('data', function (buff) {
+        var data = buff.toString();
+
+        var res = parsers.downloadStatusParser(data);
+        if (res) {
+            emitter.emit('progress', res.machine, res.progress, res.rate, res.remaining);
+        }
+    });
+    return emitter;
+};
+
+module.exports.boxList = function (args, cb) {
+    cb = cb || args;
+
+    var command = _command(['box', 'list'], args);
+    module.exports._run(command, function (err, out) {
+        if (err) {
+            return cb(err);
+        }
+        cb(null, parsers.boxListParser(out));
+    });
+};
+
+module.exports.boxOutdated = function (args, cb) {
+    cb = cb || args;
+
+    var command = _command(['box', 'outdated', '--global'], args);
+    module.exports._run(command, cb);
+};
+
+module.exports.boxPrune = function (args, cb) {
+    cb = cb || args;
+
+    var command = _command(['box', 'prune', '-f'], args);
+    module.exports._run(command, cb);
+};
+
+module.exports.boxRemove = function (name, args, cb) {
+    if (typeof name !== 'string' && cb) {
+        cb('name must be provided as a string');
+    }
+
+    cb = cb || args;
+
+    var command = _command(['box', 'remove', '-f'], args, name);
+    module.exports._run(command, cb);
+};
+
+module.exports.boxUpdate = function (box, provider, cb) {
+    if (typeof box !== 'string' && cb) {
+        cb('box must be provided as a string');
+    }
+
+    if (typeof provider !== 'string' && cb) {
+        cb('provider must be provided as a string');
+    }
+
+    var command = _command(['box', 'update', '--box', box, '--provider', provider]);
+    var proc = module.exports._run(command, cb);
+
+    var emitter = new EventEmitter;
+    proc.stdout.on('data', function (buff) {
+        var data = buff.toString();
+
+        var res = parsers.downloadStatusParser(data);
+        if (res) {
+            emitter.emit('progress', res.machine, res.progress, res.rate, res.remaining);
+        }
+    });
+    return emitter;
 };

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -139,11 +139,11 @@ function boxListOutdatedParser(out) {
 
             box.name = out.match(/[^'*\s]+(?=')/)[0];
 
-            if (out.includes('is up to date')) {
+            if (out.match(/is up to date/)) {
                 box.status = 'up to date';
                 box.currentVersion = out.match(/[^(]+(?=\))/)[0];
                 box.latestVersion = out.match(/[^(]+(?=\))/)[0];
-            } else if (out.includes('is outdated!')) {
+            } else if (out.match(/is outdated!/)) {
                 box.status = 'out of date';
                 box.currentVersion = (out.match(/(Current: ).+(?=. L)/)[0]).split(/\s/)[1];
                 box.latestVersion = (out.match(/(Latest: ).+/)[0]).split(/\s/)[1];

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -104,7 +104,15 @@ function sshConfigParser(out) {
         .map(function (out) {
             var config = {};
             for (var key in SSH_CONFIG_MATCHERS) {
-                config[key] = out.match(SSH_CONFIG_MATCHERS[key])[1];
+                var match = out.match(SSH_CONFIG_MATCHERS[key]);
+                if (match) {
+                    config[key] = match[1];
+                } else {
+                    config[key] = null;
+                    if (process.env.NODE_DEBUG) {
+                        console.warn('warning ssh-config could not parse key', key);
+                    }
+                }
             }
             return config;
         });

--- a/test/data/box-outdated.txt
+++ b/test/data/box-outdated.txt
@@ -1,0 +1,3 @@
+* 'ubuntu/trusty64' (v20170818.0.0) is up to date
+* 'my_box' wasn't added from a catalog, no version information
+* 'laravel/homestead' is outdated! Current: 2.2.0. Latest: 3.0.0

--- a/test/data/boxes.txt
+++ b/test/data/boxes.txt
@@ -1,0 +1,2 @@
+my_box      (virtualbox, 0)
+ubuntu/trusty64 (virtualbox, 20170818.0.0)

--- a/test/data/ssh-config-nokey.txt
+++ b/test/data/ssh-config-nokey.txt
@@ -1,0 +1,9 @@
+Host default
+  HostName 127.0.0.1
+  User vagrant
+  Port 2222
+  UserKnownHostsFile /dev/null
+  StrictHostKeyChecking no
+  PasswordAuthentication no
+  IdentitiesOnly yes
+  LogLevel FATAL

--- a/test/parsers-test.js
+++ b/test/parsers-test.js
@@ -58,6 +58,17 @@ describe('test parsers', function () {
             private_key: '/Users/edin-m/node-vagrant/edin-m/node-vagrant/del1/.vagrant/machines/default/virtualbox/private_key'
         }]);
     });
+    it('should test sshConfig parser', function () {
+        var data = fs.readFileSync(__dirname + '/data/ssh-config-nokey.txt').toString();
+        var res = parsers.sshConfigParser(data);
+        expect(res).to.deep.equal([{
+            host: 'default',
+            port: '2222',
+            hostname: '127.0.0.1',
+            user: 'vagrant',
+            private_key: null
+        }]);
+    });
     it('should test box list parser', function () {
         var data = fs.readFileSync(__dirname + '/data/boxes.txt').toString();
         var res = parsers.boxListParser(data);

--- a/test/parsers-test.js
+++ b/test/parsers-test.js
@@ -58,4 +58,37 @@ describe('test parsers', function () {
             private_key: '/Users/edin-m/node-vagrant/edin-m/node-vagrant/del1/.vagrant/machines/default/virtualbox/private_key'
         }]);
     });
+    it('should test box list parser', function () {
+        var data = fs.readFileSync(__dirname + '/data/boxes.txt').toString();
+        var res = parsers.boxListParser(data);
+        expect(res).to.deep.equal([{
+            name: 'my_box',
+            provider: 'virtualbox',
+            version: '0',
+        }, {
+            name: 'ubuntu/trusty64',
+            provider: 'virtualbox',
+            version: '20170818.0.0',
+        }]);
+    });
+    it('should test box outdated parser', function () {
+        var data = fs.readFileSync(__dirname + '/data/box-outdated.txt').toString();
+        var res = parsers.boxListOutdatedParser(data);
+        expect(res).to.deep.equal([{
+            name: 'ubuntu/trusty64',
+            status: 'up to date',
+            currentVersion: 'v20170818.0.0',
+            latestVersion: 'v20170818.0.0'
+        }, {
+            name: 'my_box',
+            status: 'unknown',
+            currentVersion: null,
+            latestVersion: null
+        }, {
+            name: 'laravel/homestead',
+            status: 'out of date',
+            currentVersion: '2.2.0',
+            latestVersion: '3.0.0'
+        }]);
+    });
 });


### PR DESCRIPTION
Ran into an error. I had a box configured to login with a password and not a private key (A windows box with sshd installed). Calling the sshConfig function to retrieve the port generated an error.

 This change allows the ssh-parser to return null for a property and prevents the package from throwing an exception. 

Added test for the second ssh parser scenario in which no private is present.

Apologies for stacking the commits on my previous. I am currently actively developing with the code.