### PR TITLE
Return output when there is an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ module.exports._run = function (command, opts, cb) {
 
         child.on('close', function (code) {
             if (code !== 0) {
-                return cb(err);
+                return cb(err, out);
             }
             return cb(null, out);
         });


### PR DESCRIPTION
If there is an error there may be important information that is sent to stdout. This should be preserved to allow the calling application to do something with it.