### PR TITLE
Correction to #25 and proper outdated box listing.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,12 @@ module.exports.boxOutdated = function (args, cb) {
     cb = cb || args;
 
     var command = Command.buildCommand(['box', 'outdated', '--global'], args);
-    module.exports._run(command, cb);
+    module.exports._run(command, function (err, out) {
+        if (err) {
+            return cb(err);
+        }
+        cb(null, parsers.boxListOutdatedParser(out));
+    });
 };
 
 module.exports.boxPrune = function (args, cb) {

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -155,6 +155,7 @@ function sshConfigParser(out) {
 function boxListParser(out) {
     return out.split('\n')
         .filter(nonEmptyVagrantUpdateFilter)
+        .filter(noBoxResponse)
         .map(function (out) {
             var box = {};
             for (var key in BOX_LIST_MATCHERS) {
@@ -169,12 +170,7 @@ function boxListParser(out) {
 function boxListOutdatedParser(out) {
     return out.split('\n')
         .filter(nonEmptyVagrantUpdateFilter)
-        .filter(function (line) {
-            if (line.includes('There are no installed boxes!')) {
-                return false;
-            }
-            return true;
-        })
+        .filter(noBoxResponse)
         .map(function (out) {
             var box = {};
 
@@ -195,6 +191,10 @@ function boxListOutdatedParser(out) {
             }
             return box;
         });
+}
+
+function noBoxResponse(line) {
+    return !line.includes('There are no installed boxes!');
 }
 
 function nonEmptyVagrantUpdateFilter(out) {

--- a/test/parsers-test.js
+++ b/test/parsers-test.js
@@ -84,7 +84,7 @@ describe('test parsers', function () {
     });
     it('should test box list parser - no box installed', function () {
         var data = fs.readFileSync(__dirname + '/data/box-no-box-installed.txt').toString();
-        var res = parsers.boxListOutdatedParser(data);
+        var res = parsers.boxListParser(data);
         expect(res).to.deep.equal([]);
     });
     it('should test box outdated parser', function () {


### PR DESCRIPTION
It appears I wasn't paying close enough attention before. When I created #25 I used the incorrect parser and then tested the incorrect parser.

I also identified that while I had a written the parser a test and supporting documentation the parser for the box outdated function was not being used. The function now matches the documentation. I would like to point out that someone may be depending on the old behavior and just simply ignored the documentation (or no one has ever used the box outdated function 🙁). I thought it best to correct the behavior to be correct with documentation. 

Apologies for missing both of these.

Thoughts on an elegant way to do some integration testing for the box functions? Maybe this should be discussed in a new issue?