### PR TITLE
Fix #27 - Output stdout/stderr from the spawned process

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ Events
 .on('progress', function(out) {}); // receive stdout box download progress
 ```
 
+Receive any stdout/stderr output from a child subprocess. These work only on a Machine instance:
+
+```
+.on('stdout', function(data) {}); // data is a Buffer
+.on('stderr', function(data) {}); // data is a Buffer
+```
+
 Example
 ===
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Events
 Receive any stdout/stderr output from a child subprocess. These work only on a Machine instance:
 
 ```
-.on('stdout', function(data) {}); // data is a Buffer
-.on('stderr', function(data) {}); // data is a Buffer
+machine.on('stdout', function(data) {}); // data is a Buffer
+machine.on('stderr', function(data) {}); // data is a Buffer
 ```
 
 Example

--- a/src/machine.js
+++ b/src/machine.js
@@ -51,6 +51,18 @@ Machine.prototype._run = function (command, cb) {
         }
     });
 
+    if (!!child.stdout) {
+        child.stdout.on('data', function (data) {
+            self.emit('stdout', data);
+        });
+    }
+
+    if (!!child.stderr) {
+        child.stderr.on('data', function (data) {
+            self.emit('stderr', data);
+        });
+    }
+
     return child;
 };
 


### PR DESCRIPTION
Fix #27 

Output stdout/stderr from the spawned subprocess.

Receive any stdout/stderr output from a child subprocess. These work only on a Machine instance:

```
machine.on('stdout', function(data) {}); // data is a Buffer
machine.on('stderr', function(data) {}); // data is a Buffer
```