### PR TITLE
Fix #29: provider can be null in boxUpdate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ vagrant.boxRemove(name, args, function(err, out) {});
 
 // box update
 // uses the --box and --provider flags by default
+// provider can be null and in that case no --provider arg is added
 vagrant.boxUpdate(box, provider, function(err, out) {});
     .on('progress', function(out) {});
 

--- a/src/index.js
+++ b/src/index.js
@@ -110,12 +110,13 @@ module.exports.boxUpdate = function (box, provider, cb) {
         return new EventEmitter;
     }
 
-    if (typeof provider !== 'string' && cb) {
-        cb('provider must be provided as a string');
-        return new EventEmitter;
+    var commandArgs = ['box', 'update', '--box', box];
+    if (typeof provider === 'string') {
+        commandArgs.push('--provider');
+        commandArgs.push(provider);
     }
 
-    var command = Command.buildCommand(['box', 'update', '--box', box, '--provider', provider]);
+    var command = Command.buildCommand(commandArgs);
     var proc = module.exports._run(command, cb);
 
     var emitter = new EventEmitter;

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -142,6 +142,20 @@ describe('it should test node-vagrant', function () {
             done();
         });
 
+        it('should test box update without the provider', function (done) {
+            vagrant._run = function (command) {
+                expect(command).to.be.an('array');
+                expect(command.length).to.equal(4);
+                expect(command[0]).to.equal('box');
+                expect(command[1]).to.equal('update');
+                expect(command[2]).to.equal('--box');
+                expect(command[3]).to.equal('ubuntu/trusty64');
+                done();
+                return { stdout: { on: function () { } }, stderr: { } };
+            };
+            vagrant.boxUpdate('ubuntu/trusty64', null);
+        });
+
         after(function (done) {
             vagrant._run = runFuncBeforeVagrant;
             done();


### PR DESCRIPTION
Fix #29 

Enable the `provider` arg in `vagrant.boxUpdate()` to be null, and in that case, no provider arg is set.