### PR TITLE
Update lodash dependency to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,9 +861,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lolex": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/edin-m/node-vagrant",
   "license": "ISC",
   "dependencies": {
-    "lodash": "4.17.11"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "chai": "2.1.0",


### PR DESCRIPTION
Lodash <= 4.17.11 has a Protoype Pollutation security issue (https://npmjs.com/advisories/1065), this updates the library to use the latest version of Lodash which does not have this issue, and so that downstream dependencies don't get an a npm audit issue.