### PR TITLE
Remove unused first argument from Machine.snapshots.pop

### DIFF
--- a/src/machine.js
+++ b/src/machine.js
@@ -273,7 +273,7 @@ Machine.prototype.snapshots = function () {
         push: function (cb) {
             self._generic('snapshot', 'push', cb);
         },
-        pop: function (args, cb) {
+        pop: function (cb) {
             self._generic('snapshot', 'pop', cb);
         },
         save: function (args, cb) {


### PR DESCRIPTION
This makes pop the mirror of push in that both only use a callback in their execution and do not have/need any arguments. This is a breaking change (as looking at the git history, looks like the returned object of snapshots() have always had this signature, but looking at some of the "used by" dependents on GitHub, looks like some of them are not expecting the `args`.

For example, vagrant-manager:
https://github.com/absalomedia/vagrant-manager/blob/master/app/main.js#L612-L613