### PR TITLE
Fix vagrant.machine() example to have valid cwd and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ vagrant.globalStatus('--prune', function(err, out) {});
 // create machine - does not run command or init machine
 // you can specify directory where Vagrantfile will be located
 // and machine instanced
-var machine = vagrant.create({ cwd: [], env: [] });
+var machine = vagrant.create({ cwd: process.cwd(), env: [] });
 
 // init machine
 // you can specify additional arguments by using array (applicable to other functions)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ vagrant.globalStatus('--prune', function(err, out) {});
 // create machine - does not run command or init machine
 // you can specify directory where Vagrantfile will be located
 // and machine instanced
-var machine = vagrant.create({ cwd: process.cwd(), env: {} });
+var machine = vagrant.create({ cwd: <String>, env: <Object> }) // cwd and env default to process' values
 
 // init machine
 // you can specify additional arguments by using array (applicable to other functions)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ vagrant.globalStatus('--prune', function(err, out) {});
 // create machine - does not run command or init machine
 // you can specify directory where Vagrantfile will be located
 // and machine instanced
-var machine = vagrant.create({ cwd: process.cwd(), env: [] });
+var machine = vagrant.create({ cwd: process.cwd(), env: {} });
 
 // init machine
 // you can specify additional arguments by using array (applicable to other functions)


### PR DESCRIPTION
Attempting to run the example `vagrant.create` in the README with a list for `cwd` results in the following error in Node:
```
child_process.js:422
    throw new ERR_INVALID_ARG_TYPE('options.cwd', 'string', options.cwd);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options.cwd" property must be of type string. Received type object
    at normalizeSpawnArguments (child_process.js:422:11)
    at spawn (child_process.js:534:16)
    at Object.runCommand (/Users/mpeveler/Work/Github/node-vagrant/src/command.js:48:17)
    at Machine._run (/Users/mpeveler/Work/Github/node-vagrant/src/machine.js:39:25)
    at Machine.init (/Users/mpeveler/Work/Github/node-vagrant/src/machine.js:187:14)
    at Object.<anonymous> (/Users/mpeveler/Work/Github/node-vagrant/example/example.js:90:9)
    at Module._compile (internal/modules/cjs/loader.js:936:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:947:10)
    at Module.load (internal/modules/cjs/loader.js:790:32)
    at Function.Module._load (internal/modules/cjs/loader.js:703:12)
```

Changed to use the normal default for the argument, and from which I assume someone could extrapolate that you can specify whatever string you would want.

I also updated the env to be an object as that's what ProcessEnv is, though it seems that passing in an empty array doesn't actually effect anything.