### PR TITLE
Deal with cb override first in vagrant.boxAdd

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,10 @@ module.exports.versionStatus = function (cb) {
 };
 
 module.exports.boxAdd = function (box, args, cb) {
+    cb = cb || args;
     if (typeof box !== 'string' && cb) {
         return cb('box must be provided as a string');
     }
-    cb = cb || args;
 
     var command = Command.buildCommand(['box', 'add', '-f'], args, box);
     var proc = module.exports._run(command, cb);


### PR DESCRIPTION
Test code:
```
vagrant.boxAdd(10, (err, out) => {
    console.log(err);
    console.log(out);
});
```

Current behavior:
```
$ node example.js
A name is required when adding a box file directly. Please pass
the `--name` parameter to `vagrant box add`. See
`vagrant box add -h` for more help.

==> box: Box file was not detected as metadata. Adding it directly...
```

New behavior:
```
$ node example.js
box must be provided as a string
undefined
```