### PR TITLE
Add machine command "sshCommand"

### DIFF
--- a/src/machine.js
+++ b/src/machine.js
@@ -78,6 +78,20 @@ Machine.prototype.sshConfig = function (cb) {
     });
 };
 
+Machine.prototype.sshCommand = function (cmd, cb) {
+    var command = Command.buildCommand('ssh', ['-c', cmd]);
+    var proc = this._run(command, cb);
+
+    var self = this;
+    proc.stdout.on('data', function (buff) {
+        self.emit('ssh-out', buff.toString());
+    });
+
+    proc.stderr.on('data', function(buff) {
+        self.emit('ssh-err', buff.toString());
+    });
+};
+
 Machine.prototype.status = function (cb) {
     var command = Command.buildCommand('status');
 
@@ -327,6 +341,7 @@ module.exports = Machine;
 module.exports.promisify = function () {
     if (Common.isPromised()) {
         Machine.prototype.sshConfig = util.promisify(Machine.prototype.sshConfig);
+        Machine.prototype.sshCommand = util.promisify(Machine.prototype.sshCommand);
         Machine.prototype.status = util.promisify(Machine.prototype.status);
         Machine.prototype.up = util.promisify(Machine.prototype.up);
         Machine.prototype.init = util.promisify(Machine.prototype.init);

--- a/test/machine-test.js
+++ b/test/machine-test.js
@@ -118,6 +118,41 @@ describe('it should test Machine class', function () {
             };
             machine.sshConfig();
         });
+        it('should test machine ssh command', function (done) {
+            machine._run = function (command) {
+                expect(command).to.be.an('array');
+                expect(command.length).to.equal(3);
+                expect(command[0]).to.equal('ssh');
+                done();
+            };
+            machine.sshCommand('echo test');
+        });
+        it('should test machine ssh command emit stdout', function (done) {
+            var ee = new EventEmitter;
+            var spy = sinon.spy();
+            machine._run = function (command) {
+                return { stdout: ee, stderr: new EventEmitter };
+            };
+            machine.once('ssh-out', spy);
+            machine.sshCommand('echo test');
+            ee.emit('data', 'test');
+            expect(spy.calledOnce).to.equal(true);
+            expect(spy.getCall(0).args[0]).to.equal('test');
+            done();
+        });
+        it('should test machine ssh command emit stderr', function (done) {
+            var ee = new EventEmitter;
+            var spy = sinon.spy();
+            machine._run = function (command) {
+                return { stdout: new EventEmitter, stderr: ee };
+            };
+            machine.once('ssh-err', spy);
+            machine.sshCommand('1>&2 echo test');
+            ee.emit('data', 'test');
+            expect(spy.calledOnce).to.equal(true);
+            expect(spy.getCall(0).args[0]).to.equal('test');
+            done();
+        });
         it('should test machine suspend', function (done) {
             machine._run = function (command) {
                 expect(command).to.be.an('array');


### PR DESCRIPTION
Example:
```
machine.on('ssh-out', console.log);
machine.on('ssh-err', console.error);
machine.sshCommand('echo "a bash command"');
```
Uses `vagrant ssh -c <command>`